### PR TITLE
refactor: change package name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "afrim-js"
+name = "afrim"
 version = "0.4.0"
 authors = ["Brady Fomegne <fomegnemeudje@outlook.com>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <div align="center">
 
-  <h1><code>afrim-js</code></h1>
+  <h1><code>afrim</code></h1>
 
   <strong>A binding of the <a href="https://github.com/pythonbrad/afrim">afrim ime engine</a> for the web.</strong>
 
   <p>
     <a href="https://github.com/pythonbrad/afrim-js/actions/workflows/ci.yml"><img alt="Build Status" src="https://github.com/pythonbrad/afrim-js/actions/workflows/ci.yml/badge.svg?branch=main"/></a>
-    <a href="https://www.npmjs.org/package/afrim-js"><img alt="NPM version" src="https://img.shields.io/npm/v/afrim-js.svg?style=flat-square"/></a>
+    <a href="https://www.npmjs.org/package/afrim"><img alt="NPM version" src="https://img.shields.io/npm/v/afrim.svg?style=flat-square"/></a>
   </p>
 
   <h3>
@@ -32,14 +32,14 @@ wasm-pack build
 ### Installation
 
 ```
-npm install afrim-js
+npm install afrim
 ```
 
 ### Usage
 
 ```javascript
-import { Preprocessor, Translator } from "afrim-js";
-import { convertTomlToJson } from "afrim-js";
+import { Preprocessor, Translator } from "afrim";
+import { convertTomlToJson } from "afrim";
 
 (async function () {
   // We execute preprocessor commands in idle.

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -12,7 +12,7 @@ wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn test_process() {
-    use afrim_js::Preprocessor;
+    use afrim::Preprocessor;
 
     let mut data = HashMap::new();
     data.insert("a1".to_owned(), "à".to_owned());
@@ -43,7 +43,7 @@ fn test_process() {
 
 #[wasm_bindgen_test]
 fn test_translate() {
-    use afrim_js::Translator;
+    use afrim::Translator;
     use afrim_translator::Predicate;
 
     let mut dictionary = HashMap::new();
@@ -90,7 +90,7 @@ fn test_translate() {
 #[cfg(feature = "rhai")]
 #[wasm_bindgen_test]
 fn test_transaltor() {
-    use afrim_js::Translator;
+    use afrim::Translator;
     use afrim_translator::Predicate;
 
     // Script
@@ -120,7 +120,7 @@ fn test_transaltor() {
 
 #[wasm_bindgen_test]
 fn test_toml() {
-    use afrim_js::convert_toml_to_json;
+    use afrim::convert_toml_to_json;
 
     let data = convert_toml_to_json("[data]\nhi = \"hello\"");
     assert!(data.unwrap().is_object());


### PR DESCRIPTION
### Related issues
- resolve #28 

### Change
- Changed the name from `afrim-js` to `afrim`.